### PR TITLE
Add tracking of code quality with Codeclimate and replace Coveralls with Codeclimate coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,15 @@ sudo: false
 language: node_js
 node_js:
   - "stable"
-env:
-  global:
-    - secure: VcbU15zJn1haBDK2w1FbEGhRLsDbwJ52p2Kd2cLWEpXwUAzAAwFDYzxQSD6aDUEnM25RvM78kCDv2yxKONhTXDMR5qgNGLUYnu3fG+TWhuNLVWVDzJO0Y4y0m7C1ONl0G7ILEfxMKhroptuKiha0yRExK2JZKos/j32hSdoke0A=
-    - secure: YD3KPer1EjaI2E1b11RFKhJGMc4FQtdzANFh0JyurcfOhahCuPBlS/lqEU+POlcb7qHsNKkHUkcJVXgBK7ncBxqxCqfiTAYMoxZCC62kB9+ZCeV73zFyhm+1p6y0Dnv9uh1b06z0/YzVEHt1NmVafm40U+2cBRERyViwDQLMidM=
+addons:
+    code_climate:
+        repo_token: 5dd1089105c5646ecd492907f8224b0ae64890d4befb4bbd9ebbeba55b5acb38
 cache:
   directories:
     - node_modules
 before_script:
-  - npm install -g grunt-cli
+  - npm install -g grunt-cli codeclimate-test-reporter
 script:
   - grunt build
-  - grunt test_and_coveralls
-  - travis_wait grunt saucelabs || true
+  - grunt test_and_coverage
+  - codeclimate-test-reporter < coverage/lcov.info

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,12 +26,10 @@ module.exports = function(grunt) {
       }
     },
     mocha_istanbul: {
-      coveralls: {
-        src: ['test'],
+      coverage: {
+        src: 'test',
         options: {
-          coverage:true,
-          timeout: 6000,
-          reportFormats: ['cobertura','lcovonly']
+          timeout: 6000
         }
       }
     },
@@ -129,17 +127,8 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-mocha-phantomjs');
   grunt.loadNpmTasks('grunt-saucelabs');
 
-  grunt.event.on('coverage', function(lcov, done){
-      require('coveralls').handleInput(lcov, function(err){
-          if (err) {
-              return done(err);
-          }
-          done();
-      });
-  });
-
   grunt.registerTask('build', ['uglify']);
   grunt.registerTask('test', ['browserify', 'copy:test', 'mocha_istanbul', 'mocha_phantomjs']);
-  grunt.registerTask('test_and_coveralls', ['browserify', 'copy:test', 'mocha_istanbul:coveralls', 'mocha_phantomjs']);
+  grunt.registerTask('test_and_coverage', ['browserify', 'copy:test', 'mocha_istanbul:coverage', 'mocha_phantomjs']);
   grunt.registerTask('saucelabs', ['connect', 'saucelabs-mocha']);
 };

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ scrypt-async
 ============
 
 [![Build Status](https://travis-ci.org/dchest/scrypt-async-js.svg?branch=master)](https://travis-ci.org/dchest/scrypt-async-js)
-[![Coverage Status](https://coveralls.io/repos/dchest/scrypt-async-js/badge.svg)](https://coveralls.io/r/dchest/scrypt-async-js)
+[![Test Coverage](https://codeclimate.com/github/evilaliv3/scrypt-async-js/badges/coverage.svg)](https://codeclimate.com/github/evilaliv3/scrypt-async-js/coverage)
+[![Code Climate](https://codeclimate.com/github/evilaliv3/scrypt-async-js/badges/gpa.svg)](https://codeclimate.com/github/evilaliv3/scrypt-async-js)
 
 [![Saucelabs Test Status](https://saucelabs.com/browser-matrix/dchest.svg?auth=caae471e816fc76f8d9a2c292c5f577e)](https://saucelabs.com/u/dchest)
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "devDependencies": {
     "chai": "~2.3.0",
-    "coveralls": "^2.11.2",
     "grunt": "0.4.5",
     "grunt-browserify": "~3.8.0",
     "grunt-contrib-connect": "0.10.1",


### PR DESCRIPTION
This pull requests:
- Add tracking of code quality with Codeclimate
- replace Coveralls with Codeclimate coverage

since the integration it will be possible to have the following outputs:
![screenshot from 2016-01-24 20 02 24](https://cloud.githubusercontent.com/assets/217034/12538267/e5838b18-c2d5-11e5-9e45-5f44eec13355.png)
![screenshot from 2016-01-24 20 03 11](https://cloud.githubusercontent.com/assets/217034/12538270/f17fcf80-c2d5-11e5-8c22-5aab8cb58d27.png)

it will be easy then fix issues in the code related to not standard/interoperable syntaxes

After integration the codeclimate token should be replaced with a token specific for the dchest/scrypt-async-js to be taken loggin onto https://codeclimate.com/dashboard
