### PR TITLE
Improved unit testing adding Edge, Android and Iphone testing

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
         expand: true,
         flatten: true,
         cwd: 'node_modules/',
-        src: ['mocha/mocha.css', 'mocha/mocha.js', 'chai/chai.js'],
+        src: ['mocha/mocha.css', 'mocha/mocha.js'],
         dest: 'test/lib/'
       }
     },
@@ -34,9 +34,6 @@ module.exports = function(grunt) {
           reportFormats: ['cobertura','lcovonly']
         }
       }
-    },
-    mocha_phantomjs: {
-      all: ['test/**/*.html']
     },
     'saucelabs-mocha': {
       all: {
@@ -53,11 +50,18 @@ module.exports = function(grunt) {
             },
             {
               browserName: "chrome",
-              platform: "OS X 10.10"
+              platform: "OS X 10.10",
+              version: "48"
             },
             {
               browserName: "firefox",
-              platform: "OS X 10.10"
+              platform: "OS X 10.10",
+              version: "44"
+            },
+            {
+              browserName: "microsoftedge",
+              version: "13.10586",
+              platform: "Windows 10"
             },
             {
               browserName: "internet explorer",
@@ -81,11 +85,13 @@ module.exports = function(grunt) {
             },
             {
               browserName: "chrome",
-              platform: "Windows 8.1"
+              platform: "Windows 8.1",
+              version: "beta"
             },
             {
               browserName: "firefox",
-              platform: "Windows 8.1"
+              platform: "Windows 8.1",
+              version: "beta"
             },
             {
               browserName: "iphone",
@@ -94,11 +100,33 @@ module.exports = function(grunt) {
             },
             {
               browserName: "chrome",
-              platform: "Linux"
+              platform: "Linux",
+              version: "37"
             },
             {
               browserName: "firefox",
-              platform: "Linux"
+              platform: "Linux",
+              version: "34"
+            },
+            {
+              browserName: "android",
+              platform: "Linux",
+              version: "5.1"
+            },
+            {
+              browserName: "android",
+              platform: "Linux",
+              version: "4.4"
+            },
+            {
+              browserName: "iphone",
+              platform: "OS X 10.10",
+              version: "7.1"
+            },
+            {
+              browserName: "iphone",
+              platform: "OS X 10.10",
+              version: "9.2"
             }
           ],
           public: "public",
@@ -126,7 +154,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-mocha-istanbul')
-  grunt.loadNpmTasks('grunt-mocha-phantomjs');
   grunt.loadNpmTasks('grunt-saucelabs');
 
   grunt.event.on('coverage', function(lcov, done){
@@ -139,7 +166,7 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask('build', ['uglify']);
-  grunt.registerTask('test', ['browserify', 'copy:test', 'mocha_istanbul', 'mocha_phantomjs']);
-  grunt.registerTask('test_and_coveralls', ['browserify', 'copy:test', 'mocha_istanbul:coveralls', 'mocha_phantomjs']);
+  grunt.registerTask('test', ['browserify', 'copy:test', 'mocha_istanbul']);
+  grunt.registerTask('test_and_coveralls', ['browserify', 'copy:test', 'mocha_istanbul:coveralls']);
   grunt.registerTask('saucelabs', ['connect', 'saucelabs-mocha']);
 };

--- a/package.json
+++ b/package.json
@@ -8,20 +8,16 @@
     "build": "grunt build"
   },
   "devDependencies": {
-    "chai": "~2.3.0",
-    "coveralls": "^2.11.2",
+    "coveralls": "2.11.8",
     "grunt": "0.4.5",
-    "grunt-browserify": "~3.8.0",
-    "grunt-contrib-connect": "0.10.1",
-    "grunt-contrib-copy": "~0.8.0",
-    "grunt-contrib-uglify": "0.9.1",
-    "grunt-mocha-istanbul": "^2.4.0",
-    "grunt-mocha-phantomjs": "0.6.1",
-    "grunt-saucelabs": "8.6.1",
-    "istanbul": "^0.3.13",
-    "mocha": "~2.2.4",
-    "mocha-phantomjs": "~3.5.3",
-    "phantomjs": "~1.9.16"
+    "grunt-browserify": "5.0.0",
+    "grunt-contrib-connect": "1.0.1",
+    "grunt-contrib-copy": "1.0.0",
+    "grunt-contrib-uglify": "1.0.1",
+    "grunt-mocha-istanbul": "3.0.1",
+    "grunt-saucelabs": "8.6.2",
+    "istanbul": "0.4.2",
+    "mocha": "2.4.5"
   },
   "repository": {
     "type": "git",

--- a/test/unittests.html
+++ b/test/unittests.html
@@ -7,14 +7,12 @@
   </head>
   <body>
     <div id="mocha"></div>
-    <script src="lib/chai.js"></script>
     <script src="lib/mocha.js"></script>
+    <script src="lib/unittests-bundle.js"></script>
     <script>
         mocha.setup('bdd');
         mocha.timeout(20000);
-    </script>
-    <script src="lib/unittests-bundle.js"></script>
-    <script>
+
         if (window.mochaPhantomJS) {
           mochaPhantomJS.run();
         } else {
@@ -27,9 +25,7 @@
             window.mochaResults.reports = failedTests;
           });
 
-          runner.on('fail', logFailure);
-
-          function logFailure(test, err) {
+          runner.on('fail', function (test, err) {
             var flattenTitles = function(test) {
               var titles = [];
               while (test.parent.title) {


### PR DESCRIPTION
This commit:
  - Add Edge, Android, Iphone to the tested platforms
  - Diversify versions of testing for Chrome/Firefox including: an old one, the current stable, the ongoing beta
  - Remove phantomjs; who cares of phantomjs anymore now that we have real testing?
  - remove chai library; i added it initially for error but the project has never required this.
  - Fix bug in https://github.com/dchest/scrypt-async-js/compare/master...evilaliv3:improved-unit-testing?expand=1#diff-67681eeab319685c5844c94363c9d7ddL30 were a null function was mapped to the 'fail' event, so that in case of a single failure all tests were going bad.
  - update libraries to latests versions.