### PR TITLE
Reduce nextTick calls to prevent nextTick throttling

### DIFF
--- a/scrypt-async.js
+++ b/scrypt-async.js
@@ -485,14 +485,17 @@ function scrypt(password, salt, logN, r, dkLen, interruptStep, callback, encodin
 
   function interruptedFor(start, end, step, fn, donefn) {
     (function performStep() {
-      nextTick(function() {
+      if (start % step * 10 == 0) {
+        nextTick(function () {
+          fn(start, start + step < end ? start + step : end);
+          start += step;
+          if (start < end) performStep(); else donefn();
+        });
+      } else {
         fn(start, start + step < end ? start + step : end);
         start += step;
-        if (start < end)
-          performStep();
-        else
-          donefn();
-        });
+        if (start < end) performStep(); else donefn();
+      }
     })();
   }
 


### PR DESCRIPTION
With frequently called nextTick functions, it may be possible that the browser throttles the calls and the callback is only called after a long time. This delays the application. The pull request should reduce the number of nextTick calls and counteract this behavior.

View [eth-lightwallet issue](https://github.com/ConsenSys/eth-lightwallet/issues/200) for a more detailed problem description.